### PR TITLE
Fix imports | issue #37

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 
-import { Layout, ScrollToTop } from './components';
+import { Layout, ScrollToTop } from './components/Layout';
 import { ROUTES_CONSTANTS } from './constants/routes';
 import './i18n';
 import { HomePage, MenuPage, NotFoundPage, UnderConstruction } from './pages';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,15 +1,12 @@
 import { Button, BUTTON_VARIANT } from './Button';
 import { Icon, PLATFORMS, SocialIcon } from './Icon';
-import { Layout, ScrollToTop } from './Layout';
 import { Typography, TYPOGRAPHY_CONSTANTS } from './Typography';
 
 export {
   Button,
   BUTTON_VARIANT,
   Icon,
-  Layout,
   PLATFORMS,
-  ScrollToTop,
   SocialIcon,
   Typography,
   TYPOGRAPHY_CONSTANTS


### PR DESCRIPTION
The issue was caused by a circular dependency introduced through the `./components` barrel export (`index.ts`).

To avoid the circular import chain, the import was changed to reference the module directly:

```ts
import { Layout, ScrollToTop } from './components/Layout';
```

instead of:

```ts
import { Layout, ScrollToTop } from './components';
```

This resolves the initialization error by bypassing the barrel file.
